### PR TITLE
Fixed: Comparion of Signed int with unsigned int

### DIFF
--- a/core/jni/com_android_internal_net_NetworkStatsFactory.cpp
+++ b/core/jni/com_android_internal_net_NetworkStatsFactory.cpp
@@ -175,7 +175,7 @@ static int legacyReadNetworkStatsDetail(std::vector<stats_line>* lines,
             }
         }
         s.tag = rawTag >> 32;
-        if (limitTag != -1 && s.tag != static_cast<uint32_t>(limitTag)) {
+        if (limitTag != -1 && s.tag != static_cast<int32_t>(limitTag)) {
             //ALOGI("skipping due to tag: %s", buffer);
             continue;
         }
@@ -188,7 +188,7 @@ static int legacyReadNetworkStatsDetail(std::vector<stats_line>* lines,
         if (sscanf(pos, "%u %u %" PRIu64 " %" PRIu64 " %" PRIu64 " %" PRIu64,
                 &s.uid, &s.set, &s.rxBytes, &s.rxPackets,
                 &s.txBytes, &s.txPackets) == 6) {
-            if (limitUid != -1 && static_cast<uint32_t>(limitUid) != s.uid) {
+            if (limitUid != -1 && static_cast<int32_t>(limitUid) != s.uid) {
                 //ALOGI("skipping due to uid: %s", buffer);
                 continue;
             }


### PR DESCRIPTION
frameworks/base/core/jni/com_android_internal_net_NetworkStatsFactory.cpp:178:37: error: comparison of integers of different signs: 'int32_t' (aka 'int') and 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-compare]
        if (limitTag != -1 && s.tag != static_cast<uint32_t>(limitTag)) {
                              ~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frameworks/base/core/jni/com_android_internal_net_NetworkStatsFactory.cpp:191:67: error: comparison of integers of different signs: 'uint32_t' (aka 'unsigned int') and 'int32_t' (aka 'int') [-Werror,-Wsign-compare]
            if (limitUid != -1 && static_cast<uint32_t>(limitUid) != s.uid) {
                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~
2 errors generated.

Signed-off-by: ShanuDey